### PR TITLE
Update version number to 1.3.3.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = '1.3.0' %}
+{% set version = '1.3.3' %}
 
 {% set posix = 'm2-' if win else '' %}
 {% set native = 'm2w64-' if win else '' %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,6 +26,7 @@ requirements:
   build:
     - r-base
     - r-rcpp
+    - r-rlang
     - r-lazyeval >=0.1.10
     - posix                # [win]
     - {{native}}toolchain  # [win]
@@ -34,7 +35,9 @@ requirements:
   run:
     - r-base
     - r-rcpp
+    - r-rlang
     - r-lazyeval >=0.1.10
+    - libgcc
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ build:
 requirements:
   build:
     - r-base
-    - r-rcpp
+    - r-rcpp >=0.12.3
     - r-rlang
     - r-lazyeval >=0.1.10
     - posix                # [win]
@@ -34,10 +34,9 @@ requirements:
 
   run:
     - r-base
-    - r-rcpp
+    - r-rcpp >=0.12.3
     - r-rlang
-    - r-lazyeval >=0.1.10
-    - libgcc
+    - libgcc  # [not win]
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   url:
     - https://cran.r-project.org/src/contrib/tibble_{{ version }}.tar.gz
     - https://cran.r-project.org/src/contrib/Archive/tibble/tibble_{{ version }}.tar.gz
-  sha256: 738987288a3ad9070ca9ca2f36ed47287041c21f4d1e4e4733bae2b1598845e0
+  sha256: 802ec8346eae2397a2fc64b254cf80a67c7832cb5211328336f45053ea2518ae
 
 build:
   number: 0


### PR DESCRIPTION
From what I can tell, the requirements have not changed. I am hoping that version 1.3.3 builds and can be merged.